### PR TITLE
Hotfix/20210905 1

### DIFF
--- a/gatsby/gatsby-config.js
+++ b/gatsby/gatsby-config.js
@@ -7,7 +7,7 @@ module.exports = {
     title: 'Home',
     titleTemplate: 'JR Portfolio',
     description:
-      'Jason Reid\'s Development Portfolio.',
+      'Jason Reid\'s Development Portfolio',
     url: 'https://jasonreidd.netlify.app/',
     image: '/images/icon.png',
     twitterUsername: '@JasonReidd',
@@ -61,7 +61,7 @@ module.exports = {
     {
       resolve: `gatsby-plugin-manifest`,
       options: {
-        name: `Jason Reid's Development Portfolio.`,
+        name: `Jason Reid's Development Portfolio`,
         short_name: `JR Portfolio`,
         start_url: `/`,
         background_color: `#1B1B1D`,
@@ -92,6 +92,7 @@ module.exports = {
     `gatsby-transformer-remark`,
     `gatsby-plugin-offline`,
     `gatsby-plugin-gatsby-cloud`,
+    `gatsby-plugin-catch-links`,
   ],
 };
 

--- a/gatsby/package.json
+++ b/gatsby/package.json
@@ -23,6 +23,7 @@
     "cross-env": "^7.0.3",
     "esm": "^3.2.25",
     "gatsby": "^3.11.1",
+    "gatsby-plugin-catch-links": "^3.13.0",
     "gatsby-plugin-gatsby-cloud": "^2.11.0",
     "gatsby-plugin-image": "^1.8.0",
     "gatsby-plugin-manifest": "^3.9.0",

--- a/gatsby/src/components/SEO.js
+++ b/gatsby/src/components/SEO.js
@@ -12,7 +12,7 @@ SEO.propTypes = {
 };
 SEO.defaultProps = {
   title: 'JR Portfolio',
-  description: 'Jason Reid\'s Development Portfolio.',
+  description: 'Jason Reid\'s Development Portfolio',
   image: null,
   article: false,
 };

--- a/gatsby/src/styles/GlobalStyles.js
+++ b/gatsby/src/styles/GlobalStyles.js
@@ -9,6 +9,14 @@ const GlobalStyles = createGlobalStyle`
   --orgBradfordCouncil: #293d82;
   --orgEstioTraining: #e54700;
   --orgNetConstruct: #3bb599;
+
+  // default light mode
+  --siteMain: #EEE6F0;
+  --siteSecondary: #1B1B1D;
+  --siteBoldSecondary: #000000;
+  --sitePrimaryAccent: #8B548C;
+  --siteSecondaryAccent: #5749a5;
+  --siteTertiaryAccent: #A997DF;
 }
 .theme-dark {
   --siteMain: #1B1B1D;
@@ -17,14 +25,6 @@ const GlobalStyles = createGlobalStyle`
   --sitePrimaryAccent: #8B548C;
   --siteSecondaryAccent: #A997DF;
   --siteTertiaryAccent: #FFD4CA;
-}
-.theme-light{
-  --siteMain: #EEE6F0;
-  --siteSecondary: #1B1B1D;
-  --siteBoldSecondary: #000000;
-  --sitePrimaryAccent: #8B548C;
-  --siteSecondaryAccent: #5749a5;
-  --siteTertiaryAccent: #A997DF;
 }
 .theme-custom{
   --siteMain: #FFFFFF;


### PR DESCRIPTION
gatsby-plugin-catch-links. Change description and name to remove period. Default css before theme loaded to light mode